### PR TITLE
Fix lint errors

### DIFF
--- a/cmd/greet/greet.go
+++ b/cmd/greet/greet.go
@@ -45,9 +45,9 @@ func NewGreetCmd() *cobra.Command {
 	greetCmd.Flags().StringVarP(&name, "name", "n", "", "Name to greet (default is \"World\")")
 	greetCmd.Flags().StringVarP(&format, "format", "f", "Hello, %s!", "Greeting format (use %s for the name)")
 
-	// Bind flags to viper
-	_ = viper.BindPFlag("greet.name", greetCmd.Flags().Lookup("name"))
-	_ = viper.BindPFlag("greet.format", greetCmd.Flags().Lookup("format"))
+	// Bind flags to viper and handle possible errors
+	cobra.CheckErr(viper.BindPFlag("greet.name", greetCmd.Flags().Lookup("name")))
+	cobra.CheckErr(viper.BindPFlag("greet.format", greetCmd.Flags().Lookup("format")))
 
 	return greetCmd
 }

--- a/main_test.go
+++ b/main_test.go
@@ -19,7 +19,11 @@ func TestMainIntegration(t *testing.T) {
 	cmd := exec.Command("go", "build", "-o", "test-cli-test")
 	err := cmd.Run()
 	assert.NoError(t, err, "Failed to build test binary")
-	defer func() { _ = os.Remove("test-cli-test") }()
+	defer func() {
+		if removeErr := os.Remove("test-cli-test"); removeErr != nil {
+			t.Logf("failed to remove test binary: %v", removeErr)
+		}
+	}()
 
 	output, err := exec.Command("./test-cli-test").CombinedOutput()
 	assert.NoError(t, err, "Failed to run test binary")


### PR DESCRIPTION
## Summary
- handle errors from viper.BindPFlag in greet command
- log failure to remove test binary in integration test

## Testing
- `golangci-lint run ./...`
- `go test ./... -v`
- `mise run go-test-all` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843da3233d0832a9b26d841a8699619