### PR TITLE
feat: define greet flag constants

### DIFF
--- a/cmd/greet/greet.go
+++ b/cmd/greet/greet.go
@@ -7,6 +7,14 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	flagName   = "name"
+	flagFormat = "format"
+
+	defaultName   = "World"
+	defaultFormat = "Hello, %s!"
+)
+
 // NewGreetCmd creates and returns the greet command.
 func NewGreetCmd() *cobra.Command {
 	var (
@@ -26,7 +34,7 @@ func NewGreetCmd() *cobra.Command {
 
 			// If name is still not provided, use default
 			if name == "" {
-				name = "World"
+				name = defaultName
 			}
 
 			// Format the greeting
@@ -42,12 +50,12 @@ func NewGreetCmd() *cobra.Command {
 	}
 
 	// Add local flags
-	greetCmd.Flags().StringVarP(&name, "name", "n", "", "Name to greet (default is \"World\")")
-	greetCmd.Flags().StringVarP(&format, "format", "f", "Hello, %s!", "Greeting format (use %s for the name)")
+	greetCmd.Flags().StringVarP(&name, flagName, "n", "", fmt.Sprintf("Name to greet (default is %q)", defaultName))
+	greetCmd.Flags().StringVarP(&format, flagFormat, "f", defaultFormat, "Greeting format (use %s for the name)")
 
 	// Bind flags to viper and handle possible errors
-	cobra.CheckErr(viper.BindPFlag("greet.name", greetCmd.Flags().Lookup("name")))
-	cobra.CheckErr(viper.BindPFlag("greet.format", greetCmd.Flags().Lookup("format")))
+	cobra.CheckErr(viper.BindPFlag("greet."+flagName, greetCmd.Flags().Lookup(flagName)))
+	cobra.CheckErr(viper.BindPFlag("greet."+flagFormat, greetCmd.Flags().Lookup(flagFormat)))
 
 	return greetCmd
 }

--- a/cmd/greet/greet_test.go
+++ b/cmd/greet/greet_test.go
@@ -26,21 +26,21 @@ func TestGreetCommand(t *testing.T) {
 			name:     "Default greeting",
 			args:     []string{},
 			nameFlag: "",
-			format:   "Hello, %s!",
+			format:   defaultFormat,
 			expected: "Hello, World!\n",
 		},
 		{
 			name:     "Custom name via arg",
 			args:     []string{"User"},
 			nameFlag: "",
-			format:   "Hello, %s!",
+			format:   defaultFormat,
 			expected: "Hello, User!\n",
 		},
 		{
 			name:     "Custom name via flag",
 			args:     []string{},
 			nameFlag: "Friend",
-			format:   "Hello, %s!",
+			format:   defaultFormat,
 			expected: "Hello, Friend!\n",
 		},
 		{
@@ -63,11 +63,11 @@ func TestGreetCommand(t *testing.T) {
 
 			// Set flags and args
 			if tt.nameFlag != "" {
-				err := cmd.Flags().Set("name", tt.nameFlag)
+				err := cmd.Flags().Set(flagName, tt.nameFlag)
 				require.NoError(t, err)
 			}
-			if tt.format != "Hello, %s!" {
-				err := cmd.Flags().Set("format", tt.format)
+			if tt.format != defaultFormat {
+				err := cmd.Flags().Set(flagFormat, tt.format)
 				require.NoError(t, err)
 			}
 			cmd.SetArgs(tt.args)
@@ -87,12 +87,12 @@ func TestGreetCommandFlags(t *testing.T) {
 	cmd := NewGreetCmd()
 
 	// Test name flag
-	nameFlag := cmd.Flags().Lookup("name")
+	nameFlag := cmd.Flags().Lookup(flagName)
 	assert.NotNil(t, nameFlag, "Expected name flag to be defined")
 	assert.Equal(t, "n", nameFlag.Shorthand, "Expected name flag shorthand to be 'n'")
 
 	// Test format flag
-	formatFlag := cmd.Flags().Lookup("format")
+	formatFlag := cmd.Flags().Lookup(flagFormat)
 	assert.NotNil(t, formatFlag, "Expected format flag to be defined")
 	assert.Equal(t, "f", formatFlag.Shorthand, "Expected format flag shorthand to be 'f'")
 }


### PR DESCRIPTION
## Summary
- extract flag names and defaults into constants for `greet`
- update tests to use new constants

## Testing
- `golangci-lint run ./...`
- `go test ./... -v`


------
https://chatgpt.com/codex/tasks/task_e_6843de178a28832a80f0f2c54c89aa49